### PR TITLE
Split numbers embedded in non-snake-case words

### DIFF
--- a/tests/test_compiler/test_util.py
+++ b/tests/test_compiler/test_util.py
@@ -134,6 +134,13 @@ def test_snake_case() -> None:
     assert snake_case("snakeCase") == "snake_case"
     assert snake_case("SNAKE_CASE") == "snake_case"
     assert snake_case("SNAKE_42_CASE") == "snake_42_case"
+    assert snake_case("Snake42Case") == "snake_42_case"
+    assert snake_case("SnakeCase42") == "snake_case_42"
+    assert snake_case("2Snake4Case") == "2_snake_4_case"
+    assert snake_case("SnakeCase_v2") == "snake_case_v2"
+    assert snake_case("CONSTANT1") == "constant1"
+    assert snake_case("MY_CONSTANT1") == "my_constant1"
+    assert snake_case("MY_CONSTANT_1") == "my_constant_1"
 
 
 def test_cast_or_raise() -> None:


### PR DESCRIPTION
Reasoning:
- Numbers in camelCase (e.g. camelCase123) in C are usually translated to defines by splitting them first (e.g. BYTE_SIZE_CAMEL_CASE_123). In this case, splitting numbers from letters makes sense.
- This split is not always sensible however. If a message is named MyMessage_mk2, the user has implicitly expressed that "mk" and "2" belong together, making "BYTE_SIZE_MY_MESSAGE_MK_2" an unintuitive result. An underscore in a word can therefore be interpreted as the user taking charge of the process; we should not interfere. Hence the `"_" in word` condition.
- This alone can result in inconsistencies in places where "UPPER_SNAKE_CASE" is used, however (e.g. in case of enum values and constants).  If an enum value named "TI82_PLUS" results in "ti82_plus", "TI82" should not result in "ti_82". To remedy this, I've  also excluded uppercase words.

In other words: if the user breaks convention, assume they have a reason for it. This includes:
- underscore in PascalCase or camelCase (e.g. `MyMessage_v1`, `myMessage_v1` -> `my_message_v1`)
- numbers next to words in snake_case and UPPER_CASE (e.g. `my_value1`, `MY_VALUE1` -> `my_value_v1`)